### PR TITLE
Fix JSOMR2MEI job so it can work in Rodan

### DIFF
--- a/MeiOutput.py
+++ b/MeiOutput.py
@@ -667,4 +667,4 @@ if __name__ == "__main__":
         mei_obj.add_Image(image)
     mei_string = mei_obj.run()
 
-        print("ran")
+    print("ran")

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
 __version__ = "0.1.0"
-from base import JSOM2MEI
+from base import JSOMR2MEI

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,2 @@
-import rodan
-from rodan.jobs import module_loader
-import logging
-
 __version__ = "0.1.0"
-logger = logging.getLogger('rodan')
-module_loader('rodan.jobs.JSOMR2MEI')
+from base import JSOM2MEI


### PR DESCRIPTION
Previously the job wasn't actually being imported, even though the JSOMR2MEI module itself was. This should fix it, along with another issue with the indenting in `MeiOutput.py`.